### PR TITLE
Rewrite tagbody to preprocess clauses, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,12 +257,13 @@ of the program.
 
 The `cerror` function binds a `:farolero.core/continue` restart (which can be
 called by the `continue` function) which continues as if the error never
-happened.
+happened. The first argument to `cerror` is text that describes what ignoring
+the error will do, and is used for interactive debugging.
 
 ```clojure
 (handler-bind [::error (fn [condition]
                          (continue))]
-  (cerror ::error))
+  (cerror "Ignore the error" ::error))
 ;; => nil
 ```
 


### PR DESCRIPTION
This is a hefty change, going from a sleek and relatively obvious implementation to a much more complex and obscure implementation, so my apologies up front.

The goal is to rely as little as possible on `go` blocks to transfer control to tags. Exceptions are slow (see [here](https://stackoverflow.com/questions/299068/what-are-the-effects-of-exceptions-on-performance-in-java) and [here](https://shipilev.net/blog/2014/exceptional-performance/) for examples), so it's best to avoid them where possible. In order to do that, we have to preprocess the clauses to convert any unconditional `go` blocks (`(go tag)`) or conditional `go` blocks (`(if (test) (go tag))` or `(when (test) ... (go tag))`) to extract the location of the goal tag and use it to jump directly to the tag clause. This requires changing how the clauses are "bundled", changing `:clause-body` to be a single line instead of a tag and collection of lines, so that we can parse each line individually.

In the interest of brevity, please see the comments in the code to see how it's done.