### PR TITLE
Fix CLJS errors: usage of undeclared macros and `read` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ out/
 package-lock.json
 .eastwood
 node_modules/
+.lsp/


### PR DESCRIPTION
I tried to use this library in ClojureScript but encountered numerous errors when loading the namespace. The changes in this PR have removed these errors for me.

The main issues were the usage of undeclared macros and the `read` function (not available in CLJS).
E.g.
```
------ WARNING - :undeclared-var -----------------------------------------------
 File: /Volumes/House/lib/farolero/src/cljc/farolero/core.cljc:602:9
 Can't take value of macro farolero.core/restart-case
--------------------------------------------------------------------------------
...
------ WARNING - :undeclared-var -----------------------------------------------
 File: /Volumes/House/lib/farolero/src/cljc/farolero/core.cljc:643:18
 Can't take value of macro farolero.core/wrap-exceptions
--------------------------------------------------------------------------------
...
------ WARNING - :undeclared-var -----------------------------------------------
 File: /Volumes/House/lib/farolero/src/cljc/farolero/core.cljc:643:17
 Use of undeclared Var cljs.core/read
--------------------------------------------------------------------------------
```

Summary of changes:

- Wrap all macros with `macros/deftime`
- In CLJS, use `require-macros`
- In CLJS, use `(constantly nil)` as the interactive function for the restart in `wrap-exceptions`