### PR TITLE
Babashka support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project does not follow semantic versioning. Instead its versions increment
 Any time a segment of the version number increments, all following segments are reset to zero.
 
 ## [Unreleased]
+### Added
+- Explicit support for [Babashka](https://babashka.org/).
+
 ### Fixed
 - Bug where non-keyword condition types would not correctly be handled by `*break-on-signals*`
 - Bug where `throwing-debugger` would not correctly report handler names from non-exception conditions

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,2 @@
+{:paths ["src/cljc" "classes" "resources" "test/cljc"]
+ :deps {net.cgrand/macrovich {:mvn/version "0.2.1"}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,2 +1,6 @@
-{:paths ["src/cljc" "classes" "resources" "test/cljc"]
- :deps {net.cgrand/macrovich {:mvn/version "0.2.1"}}}
+{:paths ["src/cljc" "resources"]
+ :deps {net.cgrand/macrovich {:mvn/version "0.2.1"}}
+ :tasks {test {:extra-paths ["test/cljc"]
+               :requires ([farolero.core-test :as ct]
+                          [clojure.test :as t])
+               :task (t/run-tests 'farolero.core-test)}}}

--- a/test/cljc/farolero/core_test.cljc
+++ b/test/cljc/farolero/core_test.cljc
@@ -372,14 +372,14 @@
     (t/is (= [:found-error] @state)
           "no-error clause is only run when there is no error"))
   (macros/case :clj
-    (t/is (thrown? Exception
-                   (macroexpand
-                    `(handler-case
-                         :no-error-twice
-                       (:no-error [& _args] "first")
-                       (:no-error [& _args] "second"))))
-          "only one no-error clause is allowed"))
-
+    #?(:bb nil
+       :clj (t/is (thrown? Exception
+                           (macroexpand
+                             `(handler-case
+                                :no-error-twice
+                                (:no-error [& _args] "first")
+                                (:no-error [& _args] "second"))))
+                  "only one no-error clause is allowed")))
   #?(:clj
      (t/is (= :good
               (handler-case (do @(future (sut/signal ::sut/condition))
@@ -860,3 +860,5 @@
 
 (macros/case :cljs
   (t/run-tests))
+
+#?(:bb (t/run-tests))

--- a/test/cljc/farolero/core_test.cljc
+++ b/test/cljc/farolero/core_test.cljc
@@ -371,15 +371,14 @@
       (:no-error [& _args] (vswap! state conj :no-error)))
     (t/is (= [:found-error] @state)
           "no-error clause is only run when there is no error"))
-  (macros/case :clj
-    #?(:bb nil
-       :clj (t/is (thrown? Exception
-                           (macroexpand
-                             `(handler-case
-                                :no-error-twice
-                                (:no-error [& _args] "first")
-                                (:no-error [& _args] "second"))))
-                  "only one no-error clause is allowed")))
+  #?(:bb nil
+     :clj (t/is (thrown? Exception
+                         (macroexpand
+                          `(handler-case
+                            :no-error-twice
+                            (:no-error [& _args] "first")
+                            (:no-error [& _args] "second"))))
+                "only one no-error clause is allowed"))
   #?(:clj
      (t/is (= :good
               (handler-case (do @(future (sut/signal ::sut/condition))
@@ -860,5 +859,3 @@
 
 (macros/case :cljs
   (t/run-tests))
-
-#?(:bb (t/run-tests))


### PR DESCRIPTION
Closes #18

Having solved the below issues, this is a slower but usable adaption of Farolero to Babashka.

~This is a dumb way to implement this, I admit, but I decided to sacrifice speed for availability.~

~Instead of relying on the custom Signal exception class, I've reused the clojurescript `(defrecord Signal)` and in `make-signal` I'm wrapping it in an `ex-info` and throwing that. And then I'm extending `Jump` to ExceptionInfo only in the babashka path and unwrapping the signal from the `ex-data`.~

~This works for all tests except for `test-wrap-exceptions` which makes me think that this is not the way to go, lol.~

~I don't know enough about either babashka or farolero to know how to solve this.~