### PR TITLE
Fix mapcat on keywords in throwing-debugger

### DIFF
--- a/src/cljc/farolero/core.cljc
+++ b/src/cljc/farolero/core.cljc
@@ -653,7 +653,7 @@
            (nil? (seq args)))
     (throw condition)
     (throw (ex-info "Unhandled condition" {:condition condition
-                                           :handlers (map (partial mapcat ::condition-type) *handlers*)
+                                           :handlers (into [] (comp cat (map ::condition-type)) *handlers*)
                                            :args args}
                     (when (instance? #?(:clj Throwable
                                         :cljs js/Error)


### PR DESCRIPTION
This patch fixes how `throwing-debugger` maps `*handlers*` to a sequence of keywords to be put in an ex-info.

The problem currently is that it tries to use `mapcat` where the results of f are keywords. This causes the repl printer to fail:

``` shell
clojure -Sdeps '{:deps {org.suskalo/farolero {:mvn/version "1.5.0"}}}' \
  -e "(require 'farolero.core)" \
  -e "(farolero.core/handler-bind [::foo identity ::bar identity] (farolero.core/error ::blah))"
  
Exception in thread "main" java.lang.IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.Keyword
```